### PR TITLE
6 add option to allow decay into muon pairs

### DIFF
--- a/GenOptions.dat
+++ b/GenOptions.dat
@@ -12,3 +12,4 @@ tSlope   1.13
 LUND     0
 Seed     0
 Fermi    0
+LepType	 0

--- a/JPsiGen
+++ b/JPsiGen
@@ -7,9 +7,25 @@ import sys
 
 def usage():
     print("The usage:");
-    print("python jpsigen.py -n Nsim -e Ebeam -t t_lim --Egmin Egmin --Egmax Egmax --q2Cut Q2CutValue -l (write output in LUND file)");
+    #print("python jpsigen.py -n Nsim -e Ebeam -t t_lim --Egmin Egmin --Egmax Egmax --q2Cut Q2CutValue -l (write output in LUND file)");
+    print("python jpsigen.py options");
+    print("     Available options:")
+    print("-n or --trig                      Number of events to be generated")
+    print("--seed                            The seed to be used in the random generator")
+    print("--Nperfile                        Maximum number of events to be used in the file, if number of events reaches this number, a new file is created   ")
+    print("-e                                The electron beam energy")
+    print("-t                                t_max limit in [GeV], should be a negative number")
+    print("--q2Cut                           Max Q2 for calculating the photon flux in [GeV]")
+    print("--vzMin                           Min z coordinate for the generated vertext")
+    print("--vzMax                           Max z coordinate for the generated vertext")
+    print("-s or --tSlope                    The -t slope of the cross-section dependence on -t")
+    print("-l ot --LUND                      if one, then write events in the LUND file, otherwise events will be written in a root file")
+    print("--Fermi                           The target nucleon will have an initial Fermi momentum")
+    print("-r or --Run                       Run the JPsiGen.exe in the current directory, otherwise let it find the path")
+    print("-h or--help                       Print this message")
+    print("\n\n");
     print("As an example ");
-    print("python jpsigen.py -n 100000 --LUND --Nperfile 35000 -e 10.6 -t -6 --q2Cut 0.02  --ltarg 5 --Run");
+    print("python jpsigen.py -n 100000 --LUND --Nperfile 35000 -e 10.6 -t -6 --q2Cut 0.02 --Run");
 
 def is_number(s, argument):
     try:
@@ -27,7 +43,6 @@ def main():
     NPerFile = 10000
     Eb = 10.6
     tLim = -6.
-    Ltarg = 5.
     EgMin = 4
     EgMax = 10.6
     Q2Cut = 0.02
@@ -38,11 +53,12 @@ def main():
     vz_max =  2.5;
     vz_min = -2.5;
     Fermi  = 0;
+    LepType = 0;
 
 
     try:
         #opts, args = getopt.getopt(sys.argv[1:], "n:e:t:lhor", ["help", "output=", "Nperfile=", "Egmin=", "Egmax=", "ltarg=", "q2Cut=", "LUND", "Run"])
-        opts, args = getopt.getopt(sys.argv[1:], "n:e:t:s:l:hor", ["help", "output=", "Nperfile=", "Egmin=", "Egmax=", "ltarg=", "q2Cut=", "LUND=", "Run", "trig=", "seed=", "docker", "tSlope=", "vzMin=", "vzMax=", "Fermi="])
+        opts, args = getopt.getopt(sys.argv[1:], "n:e:t:s:l:hor", ["help", "output=", "Nperfile=", "Egmin=", "Egmax=", "q2Cut=", "LUND=", "Run", "trig=", "seed=", "docker", "tSlope=", "vzMin=", "vzMax=", "Fermi=", "lep="])
     except getopt.GetoptError as err:
         # print help information and exit:
         print(err)  # will print something like "option -e not recognized"
@@ -76,9 +92,6 @@ def main():
         elif o in ("--Egmax"):
             is_number(a, o)
             EgMax = a;
-        elif o == "--ltarg":
-            is_number(a, o)
-            Ltarg = a;
         elif o in ("--q2Cut"):
             is_number(a, o)
             Q2Cut = a;
@@ -95,6 +108,9 @@ def main():
         elif o == "--Fermi":
             is_number(a, o)
             Fermi = a
+        elif o == "--lep":
+            is_number(a, o)
+            LepType = a
         elif o in ("-r", "--Run"):
             is_number(a, o)
             Run = True;
@@ -113,7 +129,6 @@ def main():
     optFile.write("NPerFile " + str(NPerFile) + "\n");
     optFile.write("Eb       " + str(Eb) + "\n");
     optFile.write("tLim     " + str(tLim)  + "\n");
-    optFile.write("lTarg    " + str(Ltarg) + "\n");
     optFile.write("EgMin    " + str(EgMin) + "\n");
     optFile.write("EgMax    " + str(EgMax) + "\n");
     optFile.write("vzMax    " + str(vz_max) + "\n");
@@ -122,7 +137,8 @@ def main():
     optFile.write("tSlope   " + str(tSlope) + "\n");
     optFile.write("LUND     " + str(LUND)  + "\n");
     optFile.write("Seed     " + str(Seed) + "\n");
-    optFile.write("Fermi    " + str(Fermi));
+    optFile.write("Fermi    " + str(Fermi) + "\n");
+    optFile.write("LepType  " + str(LepType));
 
     optFile.close()
 

--- a/JPsiGen.cc
+++ b/JPsiGen.cc
@@ -221,7 +221,7 @@ int main() {
                 
         double Eg_min = TMath::Max(Eg_minUser, Eg_thr);
         
-        // When it happens that because of the Fermi momentum the threshold the Eg threshold becomes higher
+        // When it happens that because of the Fermi momentum the Eg threshold becomes higher
         // than the Eg_max, then this is "not possible (or undesired) kinematics", so le't skip this event
         if( Eg_thr > Eg_max ){
             i = i - 1;
@@ -242,9 +242,6 @@ int main() {
 
         if (t_min > t_lim) {
             t = rand.Uniform(t_min - psf_t, t_min);
-
-            float fl_s = (float) s;
-            float fl_t = (float) t;
             
             // The x-sec is obtained in the frame where the proton is at rest, so we should move to that
             // frame, get the value of Eg, and estimate the cross-section.
@@ -287,7 +284,6 @@ int main() {
 
             L_em.Boost(Lcm.BoostVector()); // Move to the Lab Frame
             L_ep.Boost(Lcm.BoostVector()); // Move to the Lab Frame
-
 
             L_gprime.Boost(Lcm.BoostVector());
             L_prot.Boost(Lcm.BoostVector());

--- a/JPsiGen.cc
+++ b/JPsiGen.cc
@@ -182,9 +182,6 @@ int main() {
         Lund_out.open("JPsiGen.dat", ofstream::out);
     }
 
-    TH2D *h_ph_h_ph_cm1 = new TH2D("h_ph_h_ph_cm1", "", 200, 0., 360., 200, 0., 360.);
-    TH2D *h_th_g_th_cm1 = new TH2D("h_th_g_th_cm1", "", 200, 0., 180., 200, 0., 180.);
-
     TH1D *h_P_Fermi1 = new TH1D("h_P_Fermi1", "", 200, 0., 1.05);
 
     //================= Definition of Tree Variables =================
@@ -324,13 +321,7 @@ int main() {
             L_gprime.RotateZ(phi_rot);
             L_lm.RotateZ(phi_rot);
             L_lp.RotateZ(phi_rot);
-            
-            
-            tcs_kin1.SetLemLepLp(L_lm, L_lp, L_prot);
-
-            h_ph_h_ph_cm1->Fill(phi_cm * TMath::RadToDeg(), tcs_kin1.GetPhi_cm());
-            h_th_g_th_cm1->Fill(acos(cos_th) * TMath::RadToDeg(), tcs_kin1.GetTheta_cm());
-
+                        
             psf = psf_t;
 
             double eta = Q2 / (2 * (s - Mp * Mp) - Q2);
@@ -379,8 +370,6 @@ int main() {
 
     if (write_root) {
         tr1->Write();
-        h_ph_h_ph_cm1->Write();
-        h_th_g_th_cm1->Write();
         h_P_Fermi1->Write();
         file_out->Close();
     }

--- a/JPsiGen.cc
+++ b/JPsiGen.cc
@@ -48,7 +48,6 @@ int main() {
     double Eg_max;
     bool isLund;
     double q2_cut;
-    double l_targ;
     double tSlope;
     int n_perfile;
     int seed;
@@ -79,8 +78,6 @@ int main() {
             q2_cut = atof(val.c_str());
         } else if (key.compare("tSlope") == 0) {
             tSlope = atof(val.c_str());
-        } else if (key.compare("lTarg") == 0) {
-            l_targ = atof(val.c_str());
         } else if (key.compare("LUND") == 0) {
             isLund = atof(val.c_str());
         } else if (key.compare("Seed") == 0) {


### PR DESCRIPTION
* An option is added to support the decay to muon pairs; LepType, 0=electrons, 1=muons
* In addition it was found that in previous versions in the LUND file positron px,py and pz were written under pid = 11, and electron px,py and pz were written under pid=-11, this is fixed too in the new version
* The python wrapper also modified to include the option for specifying the lepton type
* In the same python wrapper the output of --help or -h, is enhanced, and it now prints more useful information in the output
* Noticed that l_targ is not being used anymore, so it is removed rom remaining codes